### PR TITLE
742 comments order

### DIFF
--- a/client/views/courses/discussion/course.discussion.html
+++ b/client/views/courses/discussion/course.discussion.html
@@ -56,7 +56,7 @@
 						title="{{dateformat time_created}}">
 						{{fromNow time_created}}
 					</span>
-					{{#if wasEdited}}
+					{{#if hasBeenEdited}}
 						<span class="comment-time-updated"
 							title="{{dateformat time_updated}}">
 							last update:{{fromNow time_updated}}
@@ -103,7 +103,7 @@
 						{{fromNow time_created}}
 					{{/unless}}
 				</span>
-				{{#if wasEdited}}
+				{{#if hasBeenEdited}}
 					<span class="comment-time-updated">
 						last update:{{fromNow time_updated}}
 					</span>

--- a/client/views/courses/discussion/course.discussion.html
+++ b/client/views/courses/discussion/course.discussion.html
@@ -56,7 +56,7 @@
 						title="{{dateformat time_created}}">
 						{{fromNow time_created}}
 					</span>
-					{{#if time_updated}}
+					{{#if wasEdited}}
 						<span class="comment-time-updated"
 							title="{{dateformat time_updated}}">
 							last update:{{fromNow time_updated}}
@@ -103,7 +103,7 @@
 						{{fromNow time_created}}
 					{{/unless}}
 				</span>
-				{{#if time_updated}}
+				{{#if wasEdited}}
 					<span class="comment-time-updated">
 						last update:{{fromNow time_updated}}
 					</span>

--- a/client/views/courses/discussion/course.discussion.js
+++ b/client/views/courses/discussion/course.discussion.js
@@ -85,7 +85,7 @@ Template.postShow.helpers({
 		return mayDeletePost(Meteor.user(), course, this);
 	},
 
-	wasEdited: function() {
+	hasBeenEdited: function() {
 		 return moment(this.time_updated).isAfter(this.time_created);
 	}
 });
@@ -122,7 +122,7 @@ Template.postEdit.helpers({
 		return Template.instance().validComment.get() ? '' : 'disabled';
 	},
 
-	wasEdited: function() {
+	hasBeenEdited: function() {
 		 return moment(this.time_updated).isAfter(this.time_created);
 	}
 });

--- a/client/views/courses/discussion/course.discussion.js
+++ b/client/views/courses/discussion/course.discussion.js
@@ -4,7 +4,7 @@ Template.discussion.onCreated(function() {
 		courseId: this.data._id,
 		parentId: { $exists: false },
 	}, {
-		sort: {time_created: -1, time_updated: -1}
+		sort: {time_updated: -1}
 	});
 });
 
@@ -37,7 +37,7 @@ Template.post.onCreated(function() {
 		this.responses = CourseDiscussions.find({
 			parentId: this.data._id,
 		}, {
-			sort: {time_created: 1, time_updated: 1}
+			sort: {time_updated: 1}
 		});
 	}
 
@@ -84,6 +84,10 @@ Template.postShow.helpers({
 		var course = Courses.findOne(this.courseId);
 		return mayDeletePost(Meteor.user(), course, this);
 	},
+
+	wasEdited: function() {
+		 return moment(this.time_updated).isAfter(this.time_created);
+	}
 });
 
 
@@ -116,6 +120,10 @@ Template.postEdit.helpers({
 
 	enableWhenValid: function() {
 		return Template.instance().validComment.get() ? '' : 'disabled';
+	},
+
+	wasEdited: function() {
+		 return moment(this.time_updated).isAfter(this.time_created);
 	}
 });
 

--- a/collections/discussions.js
+++ b/collections/discussions.js
@@ -54,7 +54,9 @@ Meteor.methods({
 			saneComment.userId = user._id;
 		}
 
-		saneComment.time_created = new Date();
+		var now = new Date();
+		saneComment.time_created = now;
+		saneComment.time_updated = now;
 
 		var course = Courses.findOne(comment.courseId);
 		if (!course) {

--- a/server/updates/2017.04.27 ensurePostTimeUpdatedField.js
+++ b/server/updates/2017.04.27 ensurePostTimeUpdatedField.js
@@ -1,0 +1,12 @@
+UpdatesAvailable.ensurePostTimeUpdatedField = function() {
+	var fetchedPosts = CourseDiscussions.find({ time_updated: null }).fetch();
+
+	// Until now it is not possible to reference a document field while updating
+	// https://stackoverflow.com/questions/3788256#3792958
+	_.each(fetchedPosts, function(post) {
+		CourseDiscussions.update(
+			{ _id: post._id },
+			{ time_updated: post.time_created }
+		);
+	});
+};

--- a/server/updates/2017.04.27 ensurePostTimeUpdatedField.js
+++ b/server/updates/2017.04.27 ensurePostTimeUpdatedField.js
@@ -1,8 +1,9 @@
 UpdatesAvailable.ensurePostTimeUpdatedField = function() {
+	// Until now it is not possible to reference a document field during an
+	// update. Therefore we have to fetch the results and iterate over them.
+	// https://stackoverflow.com/questions/3788256#3792958
 	var fetchedPosts = CourseDiscussions.find({ time_updated: null }).fetch();
 
-	// Until now it is not possible to reference a document field while updating
-	// https://stackoverflow.com/questions/3788256#3792958
 	_.each(fetchedPosts, function(post) {
 		CourseDiscussions.update(
 			{ _id: post._id },


### PR DESCRIPTION
If a comment has not been edited the `time_updated` is now just the same as `time_created`. This allows sorting the posts, so that edited ones move up to the top again when changed.

closes #742