### PR TITLE
Fix region splash behavior

### DIFF
--- a/imports/RegionSelection.js
+++ b/imports/RegionSelection.js
@@ -11,13 +11,24 @@ RegionSelection.regionDependentRoutes =
   * we just set the region to 'all regions'. */
 RegionSelection.init = function() {
 	var selectors =
-		[ Session.get('region') // The region might have been chosen already because the user is logged-in. See Accounts.onLogin().
-		, UrlTools.queryParam('region')
+		[ UrlTools.queryParam('region')
 		, localStorage.getItem('region')
 		].filter(Boolean);
 
-	// When the region is not provided we show a splash screen
-	Session.set('showRegionSplash', selectors.length < 1);
+	Tracker.autorun(function() {
+		const user = Meteor.user();
+
+		if (user) {
+			// The region might have been chosen already because the user is logged-in.
+			// See Accounts.onLogin().
+			selectors.unshift(Session.get('region'));
+		}
+
+		if (user !== undefined) {
+			// When the region is not provided we show a splash screen
+			Session.set('showRegionSplash', selectors.length < 1);
+		}
+	});
 
 	Meteor.subscribe('regions', function() {
 		var useAsRegion = function(regionId) {


### PR DESCRIPTION
Fixes #867 

The users region gets stored into the _session var_ `region` in `Accounts.onLogin()`. However the function to check `region` if there is a user region, did this before the `onLogin` had been called and therefore just got `undefined` in return.

I put an `autorun` function which observes `Meteor.user()`. It checks the `region` var only if there is a user document loaded and triggers the region splash as soon as `Meteor.user()` is either `null` or a user document.

@sbalmer However I'm not completely sure about this solution, what do you think?