### PR TITLE
don't remove the participant role from members

### DIFF
--- a/client/views/courses/members/course.members.js
+++ b/client/views/courses/members/course.members.js
@@ -9,14 +9,12 @@ Template.courseMembers.helpers({
 	},
 
 	sortedMembers: function() {
-		var members = this.members.map(function(member) {
-			member.roles = _.without(member.roles, 'participant');
-			return member;
-		});
+    	var sortedMembers = this.members.sort(function(a, b) {
+	        var aRoles = _.without(a.roles, 'participant');
+	        var bRoles = _.without(b.roles, 'participant');
 
-		var sortedMembers = members.sort(function(a, b) {
-			return b.roles.length - a.roles.length;
-		});
+	        return aRoles.length < bRoles.length;
+        });
 
 		var membersLimit = Template.instance().membersLimit.get();
 		if (membersLimit) {


### PR DESCRIPTION
fixes #894 

The error was introduced in commit 5948895370af7586d8b6848b370af700b621cb68. As a general rule, it's not a good idea to alter objects after creation time. (We're doing it in a few places, but mostly we're adding fields for display, that's "caching".)