### PR TITLE
Remove fixtures package from project by default

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -42,7 +42,6 @@ es5-shim@4.6.15
 router-autoscroll
 meteorhacks:ssr
 standard-minifier-js@2.1.1
-prng
 ccorcos:subs-cache
 fourseven:scss
 reywood:bootstrap3-sass
@@ -52,6 +51,5 @@ gadicohen:robots-txt
 shell-server@0.2.4
 ecmascript@0.8.1
 practicalmeteor:mocha
-fixtures
 dferber:prerender
 wanglian:bootstrap3-datepicker

--- a/bin/test
+++ b/bin/test
@@ -38,7 +38,7 @@ function runChimp() {
 function runMeteor() {
 	var proc = execFile(
 		'meteor',
-		[ '--production', '--settings=settings.ci.json' ]
+		[ '--production', '--settings=settings.ci.json', '--extra-packages', 'fixtures']
 	);
 
 	proc.stdout.pipe(process.stdout);


### PR DESCRIPTION
Only load the fixtures package while testing (using the `--extra-packages` command line flag). As a consequence it is necessary to set up a new dev-instance with test-data using the following command line:

```
meteor --settings settings.dev.json --extra-packages fixtures
```