### PR TITLE
Use meteor to install npm dependencies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ node_js:
 
 cache:
   directories:
-    - "$HOME/node_modules"
-    - "$HOME/.npm"
     - "$HOME/.meteor"
-    - "src/.meteor/local/build"
-    - "src/.meteor/local/bundler-cache"
-    - "src/.meteor/local/isopacks"
-    - "src/.meteor/local/plugin-cache"
-    - "src/.meteor/local/mirrors"
+    - "$HOME/.npm"
+    - "$HOME/node_modules"
+    - ".meteor/local/build"
+    - ".meteor/local/bundler-cache"
+    - ".meteor/local/isopacks"
+    - ".meteor/local/mirrors"
+    - ".meteor/local/plugin-cache"
+    - "node_modules"
 
 before_install:
   # Download Meteor
@@ -26,6 +27,7 @@ before_install:
   - chimp --browser=phantomjs --path=bin
 
 install:
+  - meteor npm install
 
 script:
   - ./bin/test


### PR DESCRIPTION
By default travis runs `npm install` inside the build directory. However, it is better to install the dependencies using `meteor npm install` because otherwise binaries will be compiled against the node version on travis instead of the one included with meteor.

Also fix dangling cache paths. Some of them seem to point to a non-existing `src` directory and hence do not have any effect on the travis cache.