### PR TITLE
register errors thrown on the client in the log

### DIFF
--- a/client/start.js
+++ b/client/start.js
@@ -1,3 +1,4 @@
+import "/imports/startup/client/clientError.js"
 import "/imports/RegionSelection.js";
 
 ////////////// db-subscriptions:

--- a/imports/api/clientError/methods.js
+++ b/imports/api/clientError/methods.js
@@ -1,0 +1,20 @@
+import '/imports/collections/Log.js';
+
+Meteor.methods({
+	clientError: function(report) {
+		check(report,
+			{ name: String
+			, message: String
+			, location: String
+			, tsClient: Date
+			}
+		);
+		const rel = [ report.name ];
+		const userId = Meteor.userId();
+		if (userId) {
+			report.userId = userId;
+			rel.push(userId);
+		}
+		Log.record('clientError', rel, report);
+	}
+});

--- a/imports/startup/client/clientError.js
+++ b/imports/startup/client/clientError.js
@@ -1,9 +1,50 @@
-window.addEventListener("error", function (event) {
+const reportToServer = function(error) {
 	var report =
-		{ name: event.error.name
-		, message: event.error.message
+		{ name: error.name
+		, message: error.message
 		, location: window.location.href
 		, tsClient: new Date()
 		};
 	Meteor.call('clientError', report);
+}
+
+window.addEventListener("error", function(event) {
+	reportToServer(event.error);
 });
+
+var buffer = [];
+var discriminatoryReporting = function(arguments) {
+	var msg = arguments[0];
+
+	// "Exception from Tracker recompute function:"
+	if (msg.indexOf("Exception ") === 0) {
+		// Boring
+		return;
+	}
+
+	// "Error: No such function: ..."
+	if (msg.indexOf("Error:") === 0) {
+		buffer.push(msg);
+		return;
+	}
+
+	// "Blaze.View.prototy..."
+	if (msg.indexOf("Blaze.") === 0) {
+		// There's a template name in there right?
+		var templateNames = /Template\.[^_]\w+/g;
+		buffer.push(msg.match(templateNames).join(','));
+		reportToServer(
+			{ name: 'TemplateError'
+			, message: buffer.join('; ')
+			}
+		);
+		return;
+	}
+};
+
+// wrap the Meteor debug function
+const meteorDebug = Meteor._debug;
+Meteor._debug = function(/* arguments */) {
+	meteorDebug.apply(this, arguments);
+	discriminatoryReporting(arguments);
+}

--- a/imports/startup/client/clientError.js
+++ b/imports/startup/client/clientError.js
@@ -5,7 +5,9 @@ const reportToServer = function(error) {
 		, location: window.location.href
 		, tsClient: new Date()
 		};
-	Meteor.call('clientError', report);
+	Meteor.call('clientError', report, function(err, result) {
+		if (err) console.log(err);
+	});
 }
 
 window.addEventListener("error", function(event) {

--- a/imports/startup/client/clientError.js
+++ b/imports/startup/client/clientError.js
@@ -1,0 +1,9 @@
+window.addEventListener("error", function (event) {
+	var report =
+		{ name: event.error.name
+		, message: event.error.message
+		, location: window.location.href
+		, tsClient: new Date()
+		};
+	Meteor.call('clientError', report);
+});

--- a/imports/startup/client/clientError.js
+++ b/imports/startup/client/clientError.js
@@ -19,8 +19,8 @@ var discriminatoryReporting = function(arguments) {
 	var msg = arguments[0];
 
 	// "Exception from Tracker recompute function:"
-	if (msg.indexOf("Exception ") === 0) {
-		// Boring
+	if (msg.indexOf("Exception from Tracker") === 0) {
+		// Boring, followed by "Error: ..."
 		return;
 	}
 

--- a/imports/startup/client/clientError.js
+++ b/imports/startup/client/clientError.js
@@ -42,6 +42,15 @@ var discriminatoryReporting = function(arguments) {
 		);
 		return;
 	}
+
+	// Sometimes an error is passed as second argument
+	if (arguments[1] instanceof Error) {
+		reportToServer(arguments[1]);
+		return;
+	}
+
+	// Log all the things!
+	reportToServer({ name: "Meteor._debug", message: arguments[0] });
 };
 
 // wrap the Meteor debug function

--- a/server/start.js
+++ b/server/start.js
@@ -1,5 +1,6 @@
 import '/imports/startup/notifications.js';
 import '/imports/startup/api.json.js';
+import '/imports/api/clientError/methods.js';
 
 Meteor.startup(function () {
 


### PR DESCRIPTION
Log all the things!

With this patch all uncaught exceptions on the client will be logged to the server.

Limitations:

1. When the network is down, this is not possible. Though meteor should queue up method calls and send the reports once a connection is established again.
2. If we trash the JS engine in some ways, it won't be able to report this to us.
3. Template errors are caught and written to the browser log, so we won't see them in the log. It looks like we'd have to patch a meteor package to get them.

By logging all client errors we track user behavior much more closely than we did before. This has privacy implications. At the moment we don't know whether  a user is browsing the site or not, as we're not logging browsing nor logging actions. With this patch, when there is a failure, we get it logged with a userId. So this will write user behavior to our log if our code is bad.

Should we do it?