### PR TITLE
only run npm install when package.json changes

### DIFF
--- a/bin/update-version
+++ b/bin/update-version
@@ -1,5 +1,11 @@
 #!/bin/sh
-meteor npm install
+
+# Check whether there was an NPM package change
+if [ "$1" ] && [ "$2" ] && git diff "$1" "$2" --name-only | grep -q package.json
+then
+	echo "Running npm install because package.json changed"
+	meteor npm install
+fi
 
 ver=$(git describe --abbrev=0)
 completeVer=$(git describe)


### PR DESCRIPTION
`meteor npm install` is shit slow so I check for changes to package.json isntead of doing this on every checkout. Is this sensible?

More importantly, is this even needed anymore?! At some point in our dark history (dad043b8a2afda8d4a170235198d95edaca2cb0c) I added this because somebody else didn't have the modules installed when they checked out. But shouldn't meteor do this?