### PR TITLE
singular event elimination - step 1

### DIFF
--- a/client/views/calendar/calendar.html
+++ b/client/views/calendar/calendar.html
@@ -2,16 +2,10 @@
 	{{> calendarNav date=startDate}}
 	<div class="container calendar-container">
 		<div class="page-component">
-			{{> calendarAddEvent}}
-		</div>
-		<div class="page-component">
 			{{#each days}}
 				{{> calendarDay day=this filter=filter}}
 				<hr>
 			{{/each}}
-		</div>
-		<div class="page-component">
-			{{> calendarAddEvent}}
 		</div>
 	</div>
 </template>

--- a/client/views/courses/edit/course.edit.html
+++ b/client/views/courses/edit/course.edit.html
@@ -18,7 +18,7 @@
 					</h2>
 					{{#unless isFrame}}
 						<span class="fa fa-info fa-fw" aria-hidden="true"></span>
-						{{mf 'course.propose.CourseInfo' 'An Openki course represents a short or long-term grassroots learning process on a more or less specific topic of interest. A new course could then range from a very draft idea inviting various collaborators to materialize it, to an already organized series of events (these are always attached to a specific course)'}}
+						{{mf 'course.propose.CourseInfo' 'A new Openki-course could range from a draft idea to an organized series of events (these are always attached to a specific course)'}}
 					{{/unless}}
 				{{/if}}
 			{{/if}}

--- a/client/views/courses/edit/course.edit.html
+++ b/client/views/courses/edit/course.edit.html
@@ -18,7 +18,7 @@
 					</h2>
 					{{#unless isFrame}}
 						<span class="fa fa-info fa-fw" aria-hidden="true"></span>
-						{{mf 'course.propose.CourseInfo' 'A new Openki-course could range from a draft idea to an organized series of events (these are always attached to a specific course)'}}
+						{{mf 'course.propose.CourseInfo' 'An Openki-course could range from a draft idea to an organized series of events or just one event.'}}
 					{{/unless}}
 				{{/if}}
 			{{/if}}

--- a/client/views/courses/edit/course.edit.html
+++ b/client/views/courses/edit/course.edit.html
@@ -18,8 +18,7 @@
 					</h2>
 					{{#unless isFrame}}
 						<span class="fa fa-info fa-fw" aria-hidden="true"></span>
-						{{mf 'course.propose.EventInfo' 'In case you want to publish a singular event, use the following form instead:'}}
-						<a href="/event/create">{{mf 'menue.CreateEvent' 'Create an event'}}</a>
+						{{mf 'course.propose.CourseInfo' 'An Openki course represents a short or long-term grassroots learning process on a more or less specific topic of interest. A new course could then range from a very draft idea inviting various collaborators to materialize it, to an already organized series of events (these are always attached to a specific course)'}}
 					{{/unless}}
 				{{/if}}
 			{{/if}}

--- a/client/views/find/find.html
+++ b/client/views/find/find.html
@@ -76,31 +76,6 @@
 			{{/if}}
 		{{/if}}
 	</div>
-	{{#if eventResults.count}}
-		<div class="page-component">
-			<div class="course-list">
-				<hr>
-				<h3>
-				{{#if results.count}}
-					{{#mf KEY='find.events.aditional_results' EVENTS=eventResults.count}}
-						{EVENTS, plural,
-							one {In addition, we found this event}
-							other {In addition, we found these # events}
-						}
-					{{/mf}}
-				{{else}}
-					{{#mf KEY='find.events.results_if_no_courses' EVENTS=eventResults.count}}
-						{EVENTS, plural,
-							one {All we found is this one event}
-							other {Yet # Events have been found}
-						}
-					{{/mf}}
-				{{/if}}
-				</h3><br />
-				{{> eventList dataEvents=eventResults withDate=true}}
-			</div>
-		</div>
-	{{/if}}
 	<div class="page-component">
 		<div class="container-sm">
 			{{> courseEdit newCourse}}

--- a/client/views/find/find.js
+++ b/client/views/find/find.js
@@ -126,13 +126,6 @@ Template.find.onCreated(function() {
 		subs.subscribe('coursesFind', filterQuery, limit, function() {
 			instance.coursesReady.set(true);
 		});
-
-		var eventQuery = filter.toQuery();
-
-		// We show events only when they're not attached to a course
-		eventQuery.standalone = true;
-		eventQuery.after = minuteTime.get();
-		instance.subscribe('eventsFind', eventQuery, 12);
 	});
 });
 
@@ -262,14 +255,6 @@ Template.find.helpers({
 		var filterQuery = instance.filter.toQuery();
 
 		return coursesFind(filterQuery, instance.courseLimit.get());
-	},
-
-
-	'eventResults': function() {
-		var filterQuery = Template.instance().filter.toQuery();
-		filterQuery.standalone = true;
-		filterQuery.after = minuteTime.get();
-		return eventsFind(filterQuery, 12);
 	},
 
 	'ready': function() {


### PR DESCRIPTION
Makes a first step towards resolving issue #924, by removing all visible references to singular events (in the home page and calendar), and including an informational text on the concepts of course and event in Openki. The text of course could be improved and perhaps made more prominent for "first-time" users with the options to remove.