### PR TITLE
More FAQ translations, links corrected

### DIFF
--- a/client/views/static/FAQ/markup/FAQ.de.md
+++ b/client/views/static/FAQ/markup/FAQ.de.md
@@ -94,9 +94,9 @@ Damit der Kurs aber im Kalender erscheint, muss jemand aus dem O-Team eine Veran
 
 <!-- TODO BILD -->
 
-
+<!--
 ### Ist es möglich, fertige Veranstaltungen auszuschreiben, ohne den Kurs zuerst vorzuschlagen?
-Ja. Ein Mentor\*in, der/die genau weiss wo und wann er/sie was lehren/vermitteln will, kann einen Kurs ohne vorangehende Diskussion ausschreiben. Er/Sie ist dann z.B. als Organisator\*in, Host und Mentor\*in des Kurses eingetragen. Ist es eine einmalige Veranstaltung tust du das über das Formular [Event erstellen](https://openki.net/event/create).
+Ja. Ein Mentor\*in, der/die genau weiss wo und wann er/sie was lehren/vermitteln will, kann einen Kurs ohne vorangehende Diskussion ausschreiben. Er/Sie ist dann z.B. als Organisator\*in, Host und Mentor\*in des Kurses eingetragen. Ist es eine einmalige Veranstaltung tust du das über das Formular [Event erstellen](https://openki.net/event/create).-->
 
 ### Wie verbindlich ist die Anmeldung für einen Kurs?
 Die Verbindlichkeit einer Kurs-Anmeldung hängt vom Kurs ab und wird im Kursbeschrieb kommuniziert.

--- a/client/views/static/FAQ/markup/FAQ.en.md
+++ b/client/views/static/FAQ/markup/FAQ.en.md
@@ -98,7 +98,7 @@ There is currently no possibility to collect course materials and document the c
 Normally, courses are held in the language in which they are published. Multilingual courses are offered in several languages.
 
 ### Why do I find numerous courses in the course overview which have already passed?
-The idea behind it is that a course is never really finished; An idea or a topic can remain current in the future. Thus users can develop a course at any time or access the documentation of it. The current courses ("Events") can be found in [Calendar](https://openki.net/calendar).
+The idea behind it is that a course is never really finished; An idea or a topic can remain current in the future. Thus users can develop a course at any time or access the documentation of it. The current courses with upcoming "Events" can be found in [Calendar](https://openki.net/calendar).
 
 
 ### I really need this tool for the organization of my course!

--- a/client/views/static/FAQ/markup/FAQ.en.md
+++ b/client/views/static/FAQ/markup/FAQ.en.md
@@ -82,14 +82,15 @@ As soon as someone proposes a course, this is published as a "suggestion" and ap
 
 However, in order for the course to appear in the calendar, someone from the O-Team must create an event. This is done after all the details (mentor, place, date, etc.) have been defined.
 
+<!--
 ### Is it possible to submit completed events without proposing the course first?
-No. In the past this was possible, but it was creating confusion and thus it was decided that every event should be linked to a course. There could be always someone that would like to continue organizing events under the same topic, and if this is not desirable the course can always be deleted.
+No. In the past this was possible, but it was creating confusion and thus it was decided that every event should be linked to a course. There could be always someone that would like to continue organizing events under the same topic, and if this is not desirable the course can always be deleted.-->
 
 ### How can I register for a course?
 The exact registration process for a course depends on the course and the O-team and is communicated in the course description.
 
 ### Where can I find courses?
-Everywhere where people come. The participants themselves are responsible for finding a suitable venue and a ["host"] (# was-ist-ein-host) for their course. All can advertise their rooms - from factory to living room to garden - so that they can be found as a venue. How you get in touch with those responsible for the room varies from room to room. We are working on a list of all possible venues in your region.
+Everywhere where people come. The participants themselves are responsible for finding a suitable venue and a ["host"](# what-is-a-host) for their course. All can advertise their rooms - from factory to living room to garden - so that they can be found as a venue. How you get in touch with those responsible for the room varies from room to room. We are working on a list of all possible venues in your region.
 
 ### Can I archive course materials, documentation, or experience reports and use them at a later date?
 There is currently no possibility to collect course materials and document the course. The goal is that the content of a course for further courses is prepared. Currently, however, the discussion, as well as shared links can be viewed in the course description. Therefore, past courses are still to be found in the course overview.
@@ -156,7 +157,8 @@ Yes! You can find the different views for embedding for your group in the group 
 Identifying and addressing discriminating content is the responsibility of all users; moderation will be carried out by the administration, which will ensure full transparency regarding censored content (never happened until today).
 
 ### How do I know if I'm in danger when attending a course?
-If you are unsure, contact the person in advance and handle according to common sense. But note that the platform does not take any responsibility regarding neither the accuracy of the information shared nor the quality of the courses or venues. If in doubt, avoid to participate in events that take place in unknown locations and/or organized by unknown people.
+If you are unsure, contact the person in advance and handle according to common sense.
+<!-- New text, to add in the german translation first/re: But note that the platform does not take any responsibility regarding neither the accuracy of the information shared nor the quality of the courses or venues. If in doubt, avoid to participate in events that take place in unknown locations and/or organized by unknown people.-->
 
 ### How does Openki protect the privacy of its users?
 Openki is keen to meet a wide variety of privacy requirements. These include modern encryption techniques as well as personalized privacy settings.

--- a/client/views/static/FAQ/markup/FAQ.en.md
+++ b/client/views/static/FAQ/markup/FAQ.en.md
@@ -1,11 +1,12 @@
 {{#template name="FAQ_en"}}
 
+## General
 
 ### What is Openki?
 
-Openki is an open education platform. Courses can be proposed, discussed, developed, organized and published. The focus is on the promotion of self-organization, the bringing together of people, groupings and initiatives, and ensure a barrier-free exchange of experiences and knowledge. The courses are accessible to all, regardless of their financial situation. The organization behind it is non-profit and OpenSource.
+Openki is an open education platform. Courses can be proposed, discussed, developed, organized and published. The focus is on the promotion of self-organization, the bringing together of people, groupings and initiatives, and ensure a barrier-free exchange of experiences and knowledge. The courses are accessible to all, regardless of their financial situation. The organization behind it is non-profit and Open Source.
 
-  [Here] (http://about.openki.net/) you will find more about Openki and its philosophy and [here] (http://about.openki.net/?page_id=1216) on the basic concepts behind the platform.
+[Here](http://about.openki.net/) you will find more about Openki and its philosophy and [here](http://about.openki.net/?page_id=1216) on the basic concepts behind the platform.
 
 ### What does the name "Openki" actually means?
 
@@ -19,13 +20,46 @@ An openki is fed on both living shrubs and trees, as later on from their dead or
 
 ### Who owns Openki?
 
-Openki belongs to me, to you and to all who participate in it. The application is open source, is available under the [GNU AGPL license] (https://www.gnu.org/licenses/agpl-3.0.de.html) and is therefore freely available for non-commercial use. Behind Openki is the collectively organized non-profit association "KOPF", which has been developing Openki during the last years.
-
+Openki belongs to me, to you and to all who participate in it. The application is open source, is available under the [GNU AGPL license](https://www.gnu.org/licenses/agpl-3.0.de.html) and is therefore freely available for non-commercial use. Behind Openki is the collectively organized non-profit association "KOPF", which has been developing Openki during the last years.
 
 ### Is Openki a social network?
 
 Yes and no. We provide a tool for self-organization. Social contacts naturally belong to this. Comparing to other providers of social media, however, we want you to stay hooked on our web site only for a little time, and then invest as much time as possible to organize collective learning processes in the real world with nice people, like you.
 
+
+### I have an idea on how Openki could be technically improved. Can I contribute my ideas?
+Nice! To make Openki even better, we need your feedback. We have also dozens of ideas that we find important, and we want to work on. But we are currently limiting ourselves to the most necessary functions because of our limited capacity to keep Openki as easy to understand as possible.
+Nevertheless, we are aware that there are several additional features that could simplify the self-organization promoted by Openki, and thus we are always very glad to receive feedback.
+
+Not only Openki's software is open-source, but its development and organization is also fully transparent. This means, for example, that you can see [here](https://github.com/Openki/Openki/issues), which are the next planned technical steps and may participate actively in the discussion there. Alternatively, you can send an email with your suggestions to: openki-core [at] lists.xiala.net.
+
+If you want to help with the translation of Openki, you will find the necessary information here: [openki.net/translate](https://openki.net/translate)
+
+
+### Who administers the Openki.net website?
+The administration and the technical maintenance (clean up, recognize problems and solve them, make improvements and much more) is done by a group of administrators working on a voluntary base mostly in Zurich but also in other Swiss cities. The goal is to set up similar administration groups for all the different resiong where Openki is (or will be) active.
+
+
+## The Openki roles
+
+### What is a participant?
+A participant is any person who participates in a course. In addition to stay informed and join the various events, participants can also take over the roles of Mentor, Host, or Organizer.
+
+### What is a Mentor?
+Mentors are expected to have a certain level of knowledge and / or experience on the topic of the course, and thus help to guide the participants through the course. They are usually responsible for the preparation and follow-up of a course.
+
+### What is an O-Team (organization team)?
+The O-Team of a specific course has the right to administer this course on the Openki platform. For example, add new "Events", change the course description and invite other participants to the O-Team. Once someone proposes a course on Openki, they automatically become the first person of the O-Team.
+
+### What is a host?
+A "host" is the person who takes care of the place where a course is held: she has access to the event room, informs about its availability in advance, could be the owner of the place or a contact person to the owner, and is responsible for ensuring that the respective "house rules" are communicated and adhered to.
+
+### What is a group?
+
+Groups are already existing organizations, communities, etc., which use Openki to organize their courses.
+
+
+## Courses
 
 ### What is an Openki-course?
 
@@ -33,15 +67,67 @@ An Openki course is much more than a typical "classroom" course, and it can incl
 
 An Openki course can start simply as a "suggestion": Somebody introduces a concept - an idea, a wish, a question. Other people can "participate" in the course, which means to stay informed and join when the course takes place. A mentor might appear in and and a venue offered by someone else. As soon as a course leads to its first planned event, "it takes place". A course can be one-time or repeated, build on other courses, or stand alone.
 
-### What is a group?
+### Which courses can be organized?
+Any type of course: from cooking to nuclear physics and modern dance to Rainer Maria Rilke. The courses are divided into categories (science, sports, music, etc.). Discriminatory content, in particular sexist and racist, is excluded.
 
-Groups are already existing organizations, communities, etc., which use Openki to organize their courses.
+### Can courses cost something?
+Yes, but all prices are intended only as a guide. As a desired donation, so to speak. This means that every one may give more or less than the suggested price, and so can participate. Only the costs (material, space, access routes ...) of a course can be fixed.
+
+### I want to host a course but have no space ...
+Depending on the region, Openki has a short or long list of available venues. All participants can also advertise their spaces - from factory to living room to garden - so that they can be found as a venue. How you get in touch with those responsible for the venue is different from venue to venue. The easiest way is to write to the user who has already written or already hosted an event in the corresponding venue (check the recent and/or past events in the venue's page).
+
+### When does a course take place?
+As soon as someone proposes a course, this is published as a "suggestion" and appears with a dashed line in the course overview.
+
+However, in order for the course to appear in the calendar, someone from the O-Team must create an event. This is done after all the details (mentor, place, date, etc.) have been defined.
+
+### Is it possible to submit completed events without proposing the course first?
+No. In the past this was possible, but it was creating confusion and thus it was decided that every event should be linked to a course. There could be always someone that would like to continue organizing events under the same topic, and if this is not desirable the course can always be deleted.
+
+### How can I register for a course?
+The exact registration process for a course depends on the course and the O-team and is communicated in the course description.
+
+### Where can I find courses?
+Everywhere where people come. The participants themselves are responsible for finding a suitable venue and a ["host"] (# was-ist-ein-host) for their course. All can advertise their rooms - from factory to living room to garden - so that they can be found as a venue. How you get in touch with those responsible for the room varies from room to room. We are working on a list of all possible venues in your region.
+
+### Can I archive course materials, documentation, or experience reports and use them at a later date?
+There is currently no possibility to collect course materials and document the course. The goal is that the content of a course for further courses is prepared. Currently, however, the discussion, as well as shared links can be viewed in the course description. Therefore, past courses are still to be found in the course overview.
+
+### In which language are the courses taking place? Why is the course description not translated?
+Normally, courses are held in the language in which they are published. Multilingual courses are offered in several languages.
+
+### Why do I find numerous courses in the course overview which have already passed?
+The idea behind it is that a course is never really finished; An idea or a topic can remain current in the future. Thus users can develop a course at any time or access the documentation of it. The current courses ("Events") can be found in [Calendar] (https://openki.net/calendar).
+
+### I really need this tool for the organization of my course!
+Many tools are already available on the web freely and humans can link them to Openki simply by link in the course description. Some examples:
+
+* Create your own wiki: [https://www.wikispaces.com/content/classroom](https://www.wikispaces.com/content/classroom)
+* Compose texts: [Etherpad](https://etherpad.wikimedia.org) or [Hackpad](https://hackpad.com)
+* Simple voting: [Dudle](https://dudle.inf.tu-dresden.de/) or [Papillon](http://papilio.niadomo.net/create/) or [Framadate](http://framadate.org)
+* More complex choices in a group: [https://loomio.org](https://loomio.org)
+* Upload files: [https://wetransfer.com/](https://wetransfer.com/)
+
+
+## Mentoring
+
+### What is a mentor?
+See ["What is a Mentor in?"](#what-is-a-mentor)
+
+### Who can be a mentor?
+All users can register for courses as mentors.
+
+### Does a course always need a mentor?
+No. There are also courses, with all participants participating equally in the learning process without needing a particular Mentor.
+
+### How do I know if a Mentor is good?
+If you are unsure, contact the person in advance. Handle according to a healthy human understanding.
 
 ### Why can not I ask for a fixed price as a mentor?
 
 We believe that education (and thus the events on Openki) should be accessible to all - regardless of one's bank account and income.
 
 
-## This page is not yet fully translated. More answers can be found in the German version of the FAQ (pls switch to German in the menue)
+## This page is not yet fully translated. More answers can be found in the German version (please switch to German in the language menu)
 
 {{/template}}

--- a/client/views/static/FAQ/markup/FAQ.en.md
+++ b/client/views/static/FAQ/markup/FAQ.en.md
@@ -97,7 +97,7 @@ There is currently no possibility to collect course materials and document the c
 Normally, courses are held in the language in which they are published. Multilingual courses are offered in several languages.
 
 ### Why do I find numerous courses in the course overview which have already passed?
-The idea behind it is that a course is never really finished; An idea or a topic can remain current in the future. Thus users can develop a course at any time or access the documentation of it. The current courses ("Events") can be found in [Calendar] (https://openki.net/calendar).
+The idea behind it is that a course is never really finished; An idea or a topic can remain current in the future. Thus users can develop a course at any time or access the documentation of it. The current courses ("Events") can be found in [Calendar](https://openki.net/calendar).
 
 ### I really need this tool for the organization of my course!
 Many tools are already available on the web freely and humans can link them to Openki simply by link in the course description. Some examples:
@@ -128,6 +128,48 @@ If you are unsure, contact the person in advance. Handle according to a healthy 
 We believe that education (and thus the events on Openki) should be accessible to all - regardless of one's bank account and income.
 
 
-## This page is not yet fully translated. More answers can be found in the German version (please switch to German in the language menu)
+## Groups
+
+### What are groups?
+Groups are already existing organizations, communities, etc. that use Openki to organize their courses.
+
+### How can we register as a group with Openki?
+Each user can create a new group under their account settings. [https://openki.net/group/create](https://openki.net/group/create)
+<! - TODO:
+### How can I take a course in my group?
+
+### How can I give all group members editing rights to a course?
+
+### Where is my group visible on Openki?
+For the time being only as a label of promoted courses
+by promoting a course by different groups, groups are linked together
+->
+
+### Can we as a group show openki courses on our own website?
+Yes! You can find the different views for embedding for your group in the group settings. More info about these views (also called _Frames_) can be found in [the Openki wiki](https://github.com/Openki/Openki/wiki/Frames)
+
+## Safety
+
+### How is abusive behaviour through Openki prevented? for example discrimination, racism etc.
+Identifying and addressing discriminating content is the responsibility of all users; moderation will be carried out by the administration, which will ensure full transparency regarding censored content (never happened until today).
+
+### How do I know if I'm in danger when attending a course?
+If you are unsure, contact the person in advance and handle according to common sense. But note that the platform does not take any responsibility regarding neither the accuracy of the information shared nor the quality of the courses or venues. If in doubt, avoid to participate in events that take place in unknown locations and/or organized by unknown people.
+
+### How does Openki protect the privacy of its users?
+Openki is keen to meet a wide variety of privacy requirements. These include modern encryption techniques as well as personalized privacy settings.
+
+Openki does not sell user data to companies, it does not track your behavior and it does not let other companies track your behavior and interests. For example, we use the share buttons of [Shariff](https://www.heise.de/ct/artikel/Shariff-Social-Media-Buttons-mit-Datenschutz-2467514.html).
+
+### How safe is the Openki webpage?
+Openki.net is SSL encrypted by default. This is the same technology that your online banking uses. But your course participation, for example, is visible to other users. So you can choose not to use your real name in Openki if you want to avoid that.
+
+
+
+## Technical
+
+### Where can I find answers to technical questions?
+Detailed technical documentation can be found in [GithubWiki](https://github.com/Openki/Openki/wiki/).
+
 
 {{/template}}


### PR DESCRIPTION
Attention to this question, which is different than the German version:

### Is it possible to submit completed events without proposing the course first?
No. In the past this was possible, but it was creating confusion and thus it was decided that every event should be linked to a course. There could be always someone that would like to continue organizing events under the same topic, and if this is not desirable the course can always be deleted.