### PR TITLE
add option to set required roles via query

### DIFF
--- a/client/views/courses/edit/course.edit.html
+++ b/client/views/courses/edit/course.edit.html
@@ -90,7 +90,7 @@
 					</div>
 					<div class="form-group-element">
 						<label>{{mf 'course.edit.needs.role' 'This course might need...'}}</label>
-						{{#each available_roles}}
+						{{#each availableRoles}}
 							{{> courseEditRole selected=../roles role=this members=../members}}
 						{{/each}}
 					</div>

--- a/client/views/courses/edit/course.edit.js
+++ b/client/views/courses/edit/course.edit.js
@@ -58,7 +58,7 @@ Template.courseEdit.helpers({
 			if (this.isFrame) {
 				const neededRoles = this.neededRoles;
 				if (neededRoles && neededRoles.length) {
-					conditions.push(neededRoles.indexOf(role.type) >= 0);
+					conditions.push(neededRoles.includes(role.type));
 				} else {
 					conditions.push(role.type !== 'host');
 				}

--- a/client/views/courses/edit/course.edit.js
+++ b/client/views/courses/edit/course.edit.js
@@ -51,8 +51,21 @@ Template.courseEdit.helpers({
 		return Template.instance().editingCategories.get();
 	},
 
-	available_roles: function() {
-		return _.filter(Roles, function(role) { return !role.preset; });
+	availableRoles() {
+		return Roles.filter(role => {
+			const conditions = [!role.preset];
+
+			if (this.isFrame) {
+				const neededRoles = this.neededRoles;
+				if (neededRoles && neededRoles.length) {
+					conditions.push(neededRoles.indexOf(role.type) >= 0);
+				} else {
+					conditions.push(role.type !== 'host');
+				}
+			}
+
+			return conditions.every(Boolean);
+		});
 	},
 
 	roleDescription: function() {

--- a/client/views/courses/edit/course.edit.js
+++ b/client/views/courses/edit/course.edit.js
@@ -53,18 +53,19 @@ Template.courseEdit.helpers({
 
 	availableRoles() {
 		return Roles.filter(role => {
-			const conditions = [!role.preset];
+			if (role.preset) return false;
 
 			if (this.isFrame) {
 				const neededRoles = this.neededRoles;
 				if (neededRoles && neededRoles.length) {
-					conditions.push(neededRoles.includes(role.type));
+					if (neededRoles.includes(role.type)) return true;
 				} else {
-					conditions.push(role.type !== 'host');
+					if (role.type !== 'host') return true;
+					return false;
 				}
+			} else {
+				return true;
 			}
-
-			return conditions.every(Boolean);
 		});
 	},
 

--- a/client/views/courses/edit/course.edit.js
+++ b/client/views/courses/edit/course.edit.js
@@ -59,9 +59,8 @@ Template.courseEdit.helpers({
 				const neededRoles = this.neededRoles;
 				if (neededRoles && neededRoles.length) {
 					if (neededRoles.includes(role.type)) return true;
-				} else {
-					if (role.type !== 'host') return true;
-					return false;
+				} else if (role.type !== 'host') {
+					return true;
 				}
 			} else {
 				return true;

--- a/client/views/frames/propose/frame.propose.js
+++ b/client/views/frames/propose/frame.propose.js
@@ -1,5 +1,6 @@
+import Filtering from '/imports/Filtering.js';
 import Metatags from '/imports/Metatags.js';
-import '/imports/Predicates.js';
+import Predicates from '/imports/Predicates.js';
 
 Router.map(function () {
 	this.route('framePropose', {
@@ -11,10 +12,11 @@ Router.map(function () {
 			const predicates =
 				{ region: Predicates.id
 				, group: Predicates.id
+				, neededRoles: Predicates.ids
 				};
 
 			const params = Filtering(predicates).read(this.params.query).done();
-			const data = params.toParams();
+			const data = params.toQuery();
 			data.isFrame = true;
 			return data;
 		},


### PR DESCRIPTION
This adds the query parameter `neededRoles` which accepts one or more roles. If it is not specified and only the checkbox for `mentor` get's displayed in the proposal frame.
closes #865

To do's:
- [x] from @1u: update documentation in wiki