### PR TITLE
Don't add URL if it's just an address

### DIFF
--- a/imports/Api.js
+++ b/imports/Api.js
@@ -10,6 +10,11 @@ const apiResponse = function(collection, formatter) {
 	};
 };
 
+const maybeUrl = function(route, context) {
+	if (!context || !context._id) return undefined;
+	return Router.url(route, context);
+};
+
 export default Api =
 	{ groups:
 		apiResponse(Groups, group => {
@@ -52,7 +57,7 @@ export default Api =
 						{ id: ev.venue._id
 						, name: ev.venue.name
 						, loc: ev.venue.loc
-						, link: Router.url('venueDetails', ev.venue)
+						, link: maybeUrl('venueDetails', ev.venue)
 						};
 				}
 


### PR DESCRIPTION
Openki allows saving just the address of an event without creating a
venue. Then there is no link to a venue either.

Fixes #1151