### PR TITLE
allow resizing editables

### DIFF
--- a/imports/ui/components/editable/editable.scss
+++ b/imports/ui/components/editable/editable.scss
@@ -69,6 +69,7 @@
 }
 
 .editable-textarea {
+	resize: vertical;
 	height: 100px;
 	overflow: auto;
 }


### PR DESCRIPTION
fixes  #1197
 
@lu40 we should also consider making the `editable` on the course-detail page resizable. But that would require turning off `max-height` of the `.tab-pane` element which complicates matters.